### PR TITLE
[add]refs #28 settingsへ日本語設定

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -108,9 +108,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ja'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Tokyo'
 
 USE_I18N = True
 


### PR DESCRIPTION
## 概要
DB起点として、タイムゾーンと言語を日本語設定に変更

## 関連
close #28

参考：
https://itc.tokyo/django/project-settings-to-start/