### PR TITLE
django-allauthをrequirements.txtに追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Django==3.2
 psycopg2>=2.8
+
+django-allauth


### PR DESCRIPTION
## 概要
認証管理機能を実装するために
`django-allauth` をインストール


## 関連



## 参考