### PR TITLE
ユーザ認証をメールアドレスで行うようにdjango-allauthで設定

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -130,7 +130,17 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # SECURE_SSL_REDIRECT = True
 
 # django-allauth
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend', #デフォルト
+    'allauth.account.auth_backends.AuthenticationBackend', #追加
+)
+
+#認証方式を 「メールアドレスとパスワード」 に変更
+ACCOUNT_AUTHENTICATION_METHOD = 'email'  #ユーザー名は使用しない
+ACCOUNT_USERNAME_REQUIRED = False  #ユーザー登録確認メールは送信しない
+ACCOUNT_EMAIL_VERIFICATION = 'none'  #メールアドレスを必須項目にする
+ACCOUNT_EMAIL_REQUIRED = True
+
 SITE_ID = 1
-## TODO: 以下、認証機能のURL構成が決定した際に編集
 LOGIN_REDIRECT_URL = 'index'
-# ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/login/'
+ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/login/'

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,6 +7,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', TemplateView.as_view(template_name='index.html'), name='index'),
     path('accounts/', include('allauth.urls')),
-    path('accounts/', include('accounts.urls')),
-    path('accounts/', include('django.contrib.auth.urls')),
+    # path('accounts/', include('accounts.urls')),  #allauthに伴い不要
+    # path('accounts/', include('django.contrib.auth.urls')),
 ]


### PR DESCRIPTION
## 概要
ユーザ認証をメールアドレスで行うように`django-allauth`に対応するよう設定

これまで、登録・ログイン画面で、ユーザー名＋pass を求めていたものを
メールアドレス＋pass とするよう、`django-allauth`パッケージを活用して変更

## 関連
close #51 


## 参考