### PR TITLE
Bootstrapで認証関係の変なところを最低限デザイン適用

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,46 +1,37 @@
 {% extends "base.html" %}
 
 {% load i18n %}
-{% load account socialaccount %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
 {% block content %}
 
-<h3 class="mb-5" >{% trans "Sign In" %}</h3>
+<div class="row justify-content-center">
+  <div class="col-lg-8 col-md-10 col-sm-12">
+    <div class="card shadow-sm">
+    
+      <div class="card-header">
+        <h4 class="my-2" >{% trans "Sign In" %}</h4>
+      </div>
 
-{% get_providers as socialaccount_providers %}
-
-{% if socialaccount_providers %}
-<p>{% blocktrans with site.name as site_name %}Please sign in with one
-of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
-for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
-
-<div class="socialaccount_ballot">
-
-  <ul class="socialaccount_providers">
-    {% include "socialaccount/snippets/provider_list.html" with process="login" %}
-  </ul>
-
-  <div class="login-or">{% trans 'or' %}</div>
-
-</div>
-
-{% include "socialaccount/snippets/login_extra.html" %}
-
-{% else %}
-<p>{% blocktrans %}If you have not created an account yet, then please
+<p class="mt-3 mx-3">{% blocktrans %}If you have not created an account yet, then please
 <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
-{% endif %}
 
-<form class="login mt-4" method="POST" action="{% url 'account_login' %}">
+<form class="login mt-3 mx-3" method="POST" action="{% url 'account_login' %}">
   {% csrf_token %}
   {{ form.as_p }}
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
-  <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
-  <button class="primaryAction btn btn-primary btn-sm mx-3" type="submit">{% trans "Sign In" %}</button>
+  <button class="primaryAction btn btn-primary btn-sm mt-3" type="submit">{% trans "Sign In" %}</button>
 </form>
+　<div class="card-footer text-muted text-center">  
+  　<a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+  </div>
+
+
+    </div>
+  </div>
+</div>
 
 {% endblock %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -3,10 +3,23 @@
 {% block title %}ユーザー登録{% endblock%}
 
 {% block content%}
-<h3 class="mb-5">ユーザー登録</h3>
-<form method="post">
-    {% csrf_token%}
-    {{form.as_p}}
-    <button class="btn btn-primary btn-sm mt-3" type="submit">ユーザー登録</button>
-</form>
+<div class="row justify-content-center">
+    <div class="col-lg-8 col-md-10 col-sm-12">
+        <div class="card mb-4 shadow-sm">
+            <div class="card-header">
+                <h4 class="my-0 font-weight-normal">ユーザー登録</h4>
+            </div>
+            <div class="card-body">
+                <form method="post" novalidate>
+                    {% csrf_token%}
+                    {{form.as_p}}
+                    <button class="btn btn-primary btn-sm mt-3" type="submit">ユーザー登録</button>
+                </form>
+            </div>
+            <div class="card-footer text-muted text-center">
+                ログインは <a href="{% url 'account_login' %}">こちら</a>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock%}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -4,22 +4,22 @@
 
 {% block content%}
 <div class="row justify-content-center">
-    <div class="col-lg-8 col-md-10 col-sm-12">
-        <div class="card mb-4 shadow-sm">
-            <div class="card-header">
-                <h4 class="my-0 font-weight-normal">ユーザー登録</h4>
-            </div>
-            <div class="card-body">
-                <form method="post" novalidate>
-                    {% csrf_token%}
-                    {{form.as_p}}
-                    <button class="btn btn-primary btn-sm mt-3" type="submit">ユーザー登録</button>
-                </form>
-            </div>
-            <div class="card-footer text-muted text-center">
-                ログインは <a href="{% url 'account_login' %}">こちら</a>
-            </div>
-        </div>
+  <div class="col-lg-8 col-md-10 col-sm-12">
+    <div class="card mb-4 shadow-sm">
+      <div class="card-header">
+        <h4 class="my-2 font-weight-normal">ユーザー登録</h4>
+      </div>
+      <div class="card-body">
+        <form method="post" novalidate>
+          {% csrf_token%}
+          {{form.as_p}}
+            <button class="btn btn-primary btn-sm mt-3" type="submit">ユーザー登録</button>
+        </form>
+      </div>
+      <div class="card-footer text-muted text-center">
+        ログインは <a href="{% url 'account_login' %}">こちら</a>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock%}


### PR DESCRIPTION
## 概要
- signup.html
- login.html
  - ソーシャル認証の情報が公式テンプレートから持ってきたものに入っていたため削除
  - signup.html　と同様に最低限いい感じにデザインを修正 


<table>
<tr>
<td><img src="https://user-images.githubusercontent.com/92197575/209429834-f8c883d9-252b-4cf0-b17f-9d1a46b1cde9.png" height="300"></td>
<td><img src="https://user-images.githubusercontent.com/92197575/209429837-0ee228f9-65aa-4f7b-bc6c-05e7ea38d9d2.png" height="300" ></td>
</tr>
</table>



## 関連



## 参考
現場で使える：実践編

## 備考
以下、最新バージョンにつき調査時注意要
```
django-bootstrap5
bootstrap5　
```

## 課題
{{ form.as_p }} よりも内側の要素をデザインしたい場合、工夫が必要（for form in item ...）
https://github.com/pennersr/django-allauth/blob/master/allauth/account/forms.py