### PR TITLE
飲み会作成フォームの実装

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -147,5 +147,5 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'  #登録確認メールを送信しない
 ACCOUNT_LOGOUT_ON_GET = True #確認画面無しのログアウト
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = '/'
+LOGIN_REDIRECT_URL = 'party/'
 ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/login/'

--- a/config/settings.py
+++ b/config/settings.py
@@ -147,5 +147,5 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'  #登録確認メールを送信しない
 ACCOUNT_LOGOUT_ON_GET = True #確認画面無しのログアウト
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = 'party/'
+LOGIN_REDIRECT_URL = 'party:index'
 ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/login/'

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,5 +6,5 @@ from django.views.generic import TemplateView
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include('allauth.urls')),
-    path('', include('party.urls')),
+    path('party/', include('party.urls')),
 ]

--- a/party/admin.py
+++ b/party/admin.py
@@ -2,9 +2,9 @@ from django.contrib import admin
 
 from .models import Party
 
-
-class PartyAdmin(admin.ModelAdmin):
-    list_display = ('id','title')
-    list_display_links = ('id','title')
+# # TODO:管理画面へ反映されない
+# class PartyAdmin(admin.ModelAdmin): 
+#     list_display = ('title','restaurant','subscriber')
+#     list_display_links = ('title','restaurant','subscriber')
 
 admin.site.register(Party)

--- a/party/forms.py
+++ b/party/forms.py
@@ -8,6 +8,8 @@ class PartyForm(ModelForm):
     class Meta:
         model = Party
         fields = [
-        'title', 'date', 'time', 'restaurant', 'address', 'url',
+        'user', 'title', 'date', 'time', 'restaurant', 'address', 'url',
         'subscriber', 'fee','comment','create_dt','mod_dt',
         ]
+
+# TODO: NULL制約により、user,create_dt,mod_dt の登録が必須となっているため、対処する

--- a/party/forms.py
+++ b/party/forms.py
@@ -1,0 +1,13 @@
+from django.forms import ModelForm
+
+from .models import Party
+
+
+class PartyForm(ModelForm):
+
+    class Meta:
+        model = Party
+        fields = [
+        'title', 'date', 'time', 'restaurant', 'address', 'url',
+        'subscriber', 'fee','comment','create_dt','mod_dt',
+        ]

--- a/party/models.py
+++ b/party/models.py
@@ -42,10 +42,10 @@ class Party(models.Model):
         verbose_name='コメント'
     )
     create_dt = models.DateTimeField(
-        verbose_name='作成日時'
+        verbose_name='作成日時' #自動的にしたい場合 auto_now_add=True
     )
     mod_dt = models.DateTimeField(
-        verbose_name='編集日時'
+        verbose_name='編集日時' #自動的にしたい場合 auto_now=True
     )
 
     def __str__(self):

--- a/party/urls.py
+++ b/party/urls.py
@@ -6,5 +6,6 @@ from . import views
 app_name = 'party'
 
 urlpatterns = [
-    path('', views.index_view, name='index'), #関数ベース
+    path('', views.IndexView.as_view(), name='index'),
+    path('create/', views.CreatePartyView.as_view(), name='create'),
 ]

--- a/party/views.py
+++ b/party/views.py
@@ -19,7 +19,7 @@ class CreatePartyView(CreateView):
     success_url = reverse_lazy('party:index')
 
     def form_valid(self, form):
-        create_data = form.save(commit=False)
+        create_data = form.save()
         create_data.user = self.request.user
         create_data.save()
         return super().form_valid(form)

--- a/party/views.py
+++ b/party/views.py
@@ -1,5 +1,25 @@
 from django.shortcuts import render
+from django.views.generic import TemplateView
+from django.views.generic import CreateView
+from django.urls import reverse_lazy
+
+from .forms import PartyForm
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import login_required
 
 
-def index_view(request):
-    return render(request, 'index.html') # templates/idex.html
+class IndexView(TemplateView):
+    template_name = "index.html"
+
+
+@method_decorator(login_required, name='dispatch')
+class CreatePartyView(CreateView):
+    form_class = PartyForm
+    template_name = "party/create_party.html"
+    success_url = reverse_lazy('party:index')
+
+    def form_valid(self, form):
+        create_data = form.save(commit=False)
+        create_data.user = self.request.user
+        create_data.save()
+        return super().form_valid(form)

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,10 @@
 <body style="background-color:#ece8e0;">
 <nav class="navbar navbar-expand-md navbar-custom fixed-top mb-2 bg-warning">
   <div class="container-fluid">
-      <a class="navbar-brand" href="/">DRPT</a>
+      <a class="navbar-brand" href="{% url 'party:index' %}">DRPT</a>
+  </div>
+  <div class="container-fluid">
+      <a class="navbar-brand" href="{% url 'party:create' %}">CREATE</a>
   </div>
 </nav>
 <main class="container" >

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}ホーム{% endblock %}
+{% block title %}home{% endblock %}
 
 {% block content %}
-<h2 class=mb-5>ホーム</h2>
+<h2 class=mb-5>HOME</h2>
 {% if user.is_authenticated %}
 Welcome ! {{ user.get_username }} さん
 <p><a href="{% url 'account_logout' %}">ログアウト</a></p>

--- a/templates/party/create_party.html
+++ b/templates/party/create_party.html
@@ -1,6 +1,10 @@
-{% comment %} {% extends 'base.html' %} {% endcomment %}
+{% comment %} {% extends 'base.html' %} {% endcomment %} <!-- TODO:継承するとフォーム画面が表示されなくなるため対応 -->
 
-{% comment %} {% block title %}飲み会作成{% endblock %} {% endcomment %}
+    <a class="navbar-brand" href="{% url 'party:index' %}">DRPT</a> <!-- TODO:作業用リンク -->
+    <br><br>
+
+{% block title %}DRPT CREATE{% endblock %}
+    
 
     {% block contents %}
     
@@ -8,54 +12,9 @@
     <div class="container">
     <div class="row">
     <div class="col offset-2">
-    <form method ="POST">
+    <form method="POST">
     {% csrf_token %}
-    <table>
-      <tr>
-        <th>飲み会名</th>
-        <td>{{ form.title }}</td>
-      </tr>
-      <tr>
-        <th>予約日</th>
-        <td>{{ form.date }}</td>
-      </tr>
-      <tr>
-        <th>時間</th>
-        <td>{{ form.time }}</td>
-      </tr>
-      <tr>
-        <th>店舗名</th>
-        <td>{{ form.restaurant }}</td>
-      </tr>
-      <tr>
-        <th>場所</th>
-        <td>{{ form.address }}</td>
-      </tr>
-      <tr>
-        <th>店舗リンク</th>
-        <td>{{ form.url }}</td>
-      </tr>
-      <tr>
-        <th>予約者名</th>
-        <td>{{ form.subscriber }}</td>
-      </tr>
-      <tr>
-        <th>会費</th>
-        <td>{{ form.fee }}</td>
-      </tr>
-      <tr>
-        <th>コメント</th>
-        <td>{{ form.comment }}</td>
-      </tr>
-      <tr>
-        <th>作成日時</th>
-        <td>{{ form.create_dt }}</td>
-      </tr>
-      <tr>
-        <th>編集日時</th>
-        <td>{{ form.mod_dt }}</td>
-      </tr>
-    </table>
+    {{ form.as_p }}
     <br>
     <button type="submit">作成する</button>
     </form>

--- a/templates/party/create_party.html
+++ b/templates/party/create_party.html
@@ -1,0 +1,66 @@
+{% comment %} {% extends 'base.html' %} {% endcomment %}
+
+{% comment %} {% block title %}飲み会作成{% endblock %} {% endcomment %}
+
+    {% block contents %}
+    
+    <br>
+    <div class="container">
+    <div class="row">
+    <div class="col offset-2">
+    <form method ="POST">
+    {% csrf_token %}
+    <table>
+      <tr>
+        <th>飲み会名</th>
+        <td>{{ form.title }}</td>
+      </tr>
+      <tr>
+        <th>予約日</th>
+        <td>{{ form.date }}</td>
+      </tr>
+      <tr>
+        <th>時間</th>
+        <td>{{ form.time }}</td>
+      </tr>
+      <tr>
+        <th>店舗名</th>
+        <td>{{ form.restaurant }}</td>
+      </tr>
+      <tr>
+        <th>場所</th>
+        <td>{{ form.address }}</td>
+      </tr>
+      <tr>
+        <th>店舗リンク</th>
+        <td>{{ form.url }}</td>
+      </tr>
+      <tr>
+        <th>予約者名</th>
+        <td>{{ form.subscriber }}</td>
+      </tr>
+      <tr>
+        <th>会費</th>
+        <td>{{ form.fee }}</td>
+      </tr>
+      <tr>
+        <th>コメント</th>
+        <td>{{ form.comment }}</td>
+      </tr>
+      <tr>
+        <th>作成日時</th>
+        <td>{{ form.create_dt }}</td>
+      </tr>
+      <tr>
+        <th>編集日時</th>
+        <td>{{ form.mod_dt }}</td>
+      </tr>
+    </table>
+    <br>
+    <button type="submit">作成する</button>
+    </form>
+    </div>
+    </div>
+    </div>
+
+    {% endblock %}


### PR DESCRIPTION
## 概要
- 飲み会作成用のフォームを実装する
- それに伴う、ルーティング、ビュー、テンプレートを実装する
- データベースへフォームの作成内容が保存されること
  - `form.as_p` で成功（`form.fiedl_name`だと保存されない現象に見舞われた） 

## 関連
close #76


## 備考
- モデル定義のリレーションか、NULL制約かで、フォームでの`user`, `create_dt`, `mod_dt` の登録が必須となっているため、対処する。
- `form.as_p` よりも粒度の細かいフィールドをフォームに表示させる場合の方法を確認する。

## 参考
