### PR TITLE
カスタムフォームを作成・適用

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,69 @@
+from allauth.account.forms import (
+    SignupForm,
+    LoginForm,
+    ResetPasswordForm,
+    ResetPasswordKeyForm,
+    ChangePasswordForm,
+    AddEmailForm,
+    SetPasswordForm, 
+)
+
+
+#allauthのsignupフォーム上書き
+class CustomSignupForm(SignupForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+#allauthのログインフォーム上書き
+class CustomLoginForm(LoginForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        #form-control
+        self.fields['login'].widget.attrs['class'] = 'form-control'
+        self.fields['password'].widget.attrs['class'] = 'form-control'
+        self.fields['remember'].widget.attrs['class'] = 'checkbox'
+        #placeholder
+        self.fields['login'].widget.attrs['placeholder'] = ''
+        self.fields['password'].widget.attrs['placeholder'] = ''
+        self.fields['remember'].widget.attrs['placeholder'] = ''
+        #label
+        self.fields['login'].label = 'メールアドレス' #email入力用のfieldだが、allauthのfields名は'login'
+        self.fields['password'].label = 'パスワード'
+        self.fields['remember'].label = 'stay_login'
+
+#allauthのパスワードリセットのメールフォーム上書き
+class CustomResetPasswordForm(ResetPasswordForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+#allauthのnewパスワードフォーム上書き
+class CustomResetPasswordKeyForm(ResetPasswordKeyForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+#allauthのパスワード変更フォーム上書き
+class CustomChangePasswordForm(ChangePasswordForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+#allauthのメール設定フォーム上書き
+class CustomAddEmailForm(AddEmailForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+#allauthのパスワード設定フォーム
+class CustomSetPasswordForm(SetPasswordForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'

--- a/config/settings.py
+++ b/config/settings.py
@@ -162,3 +162,14 @@ BOOTSTRAP_DATEPICKER_PLUS = {
         },
     }
 }
+
+#allauth formのカスタム
+ACCOUNT_FORMS = {
+    'signup': 'accounts.forms.CustomSignupForm',
+    'login': 'accounts.forms.CustomLoginForm',
+    'reset_password': 'accounts.forms.CustomResetPasswordForm',
+    'reset_password_from_key': 'accounts.forms.CustomResetPasswordKeyForm',
+    'change_password': 'accounts.forms.CustomChangePasswordForm',
+    'add_email': 'accounts.forms.CustomAddEmailForm',
+    'set_password': 'accounts.forms.CustomSetPasswordForm',
+}

--- a/party/forms.py
+++ b/party/forms.py
@@ -7,6 +7,10 @@ from .models import Party
 
 
 class PartyCreateForm(ModelForm):
+    def __init__(self, *args, **kwargs):
+            super(PartyCreateForm, self).__init__(*args, **kwargs)
+            for field in self.fields.values():
+                field.widget.attrs["class"] = "form-control"
 
     class Meta:
         model = Party

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@ Welcome ! {{ user.get_username }} さん
             備考 : {{ record.comment| truncatechars:30 }}
             作成者 : {{ record.user }}
           </ul>
-          <div style='font-size: 5px'>作成日 : {{ record.create_dt }}</div><div style='font-size: 5px'>更新日 : {{ record.mod_dt }}</div>
+          <div class='mt-3' style='font-size: 5px'>作成日 : {{ record.create_dt }}</div><div style='font-size: 5px'>更新日 : {{ record.mod_dt }}</div>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## 概要
-  Bootstrap適用のためカスタムのフォームを作成・適用
- django-allauth へカスタムフォームを適用
- 飲み会作成画面のフォーム（class）へ`form-control`を適用

- **これにて、現状の認証周りと作成フォームへの最低限のデザイン適用は完了** 

## 関連
close #89


## 備考
- django-allauth のフィールドに関して、公式のGitHub内を確認
- settings.py への上書きをしているため、今後のデザイン調整時には注意が必要


## 参考
https://django-allauth.readthedocs.io/en/latest/installation.html

https://github.com/pennersr/django-allauth/blob/master/allauth/account/forms.py#L93

https://qiita.com/NOIZE/items/0522825a1de1d6aa4a2b