### PR TITLE
update: --comment

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -31,7 +31,7 @@ class CustomLoginForm(LoginForm):
         #label
         self.fields['login'].label = 'メールアドレス' #email入力用のfieldだが、allauthのfields名は'login'
         self.fields['password'].label = 'パスワード'
-        self.fields['remember'].label = 'stay_login'
+        self.fields['remember'].label = 'ログイン状態を維持する'
 
 #allauthのパスワードリセットのメールフォーム上書き
 class CustomResetPasswordForm(ResetPasswordForm):

--- a/config/settings.py
+++ b/config/settings.py
@@ -119,10 +119,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = '/static/'
-STATICFILES_DIRS = [BASE_DIR / "static_local" ] # Todo:static_local を暫定的に指定
+STATICFILES_DIRS = [BASE_DIR / "static_local" ] # 開発環境
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = BASE_DIR / "media_local" # Todo:media_local を暫定的に指定
+MEDIA_ROOT = BASE_DIR / "media_local" # 開発環境
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field

--- a/templates/party/party_detail.html
+++ b/templates/party/party_detail.html
@@ -43,7 +43,7 @@
 
 {% block extrajs %}
 <script type="text/javascript">
-  /* 飲み会への参加 */
+  /* 飲み会への参加ボタン */
   document.getElementById('ajax-join_for_party').addEventListener('click', e => {
     e.preventDefault();
     const url = '{% url "party:join_for_party" %}';


### PR DESCRIPTION
## 概要
- 当初、staticフォルダの整理とJSファイルのエンプレートからの分離を目的にissue作成した
- 一旦、現状のJSがテンプレートタグとの親和性高く、分離による保守性が悪化することから本件クローズ
- 静的ファイルの扱いについて学習が進んだこともクローズの一因


## 関連
close #101
close #17


## 備考



## 参考
