### PR TITLE
飲み会削除機能の実装

### DIFF
--- a/party/urls.py
+++ b/party/urls.py
@@ -8,6 +8,7 @@ app_name = 'party'
 urlpatterns = [
     path('', views.IndexView.as_view(), name='index'),
     path('create_party/', views.PartyCreateView.as_view(), name='create_party'),
+    path('delete_party/<int:pk>', views.PartyDeleteView.as_view(), name='delete_party'),
     path('party_detail/<int:pk>', views.PartyDetailView.as_view(), name='party_detail'),
     path('join_for_party/', views.join_for_party, name='join_for_party'),
     path('not_join_for_party/', views.not_join_for_party, name='not_join_for_party'),

--- a/party/views.py
+++ b/party/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.views.generic import TemplateView, ListView, DetailView
+from django.views.generic import TemplateView, ListView, DetailView, DeleteView
 from django.views.generic import CreateView
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
@@ -12,14 +12,14 @@ from .models import Party, JoinForParty, NotJoinForParty, TbdForParty
 
 
 class IndexView(ListView):
-    template_name = "index.html"
+    template_name = 'index.html'
     queryset = Party.objects.order_by('-date')
 
 
 @method_decorator(login_required, name='dispatch')
 class PartyCreateView(CreateView):
     form_class = PartyCreateForm
-    template_name = "party/create_party.html"
+    template_name = 'party/create_party.html'
     success_url = reverse_lazy('party:index')
 
     def form_valid(self, form):
@@ -27,6 +27,13 @@ class PartyCreateView(CreateView):
         create_data.user = self.request.user
         create_data.save()
         return super().form_valid(form)
+
+
+class PartyDeleteView(DeleteView):
+    template_name = 'party/delete_party.html'
+    model = Party
+    success_url = reverse_lazy('party:index')
+
 
 class PartyDetailView(DetailView):
     template_name = 'party/party_detail.html'

--- a/templates/party/delete_party.html
+++ b/templates/party/delete_party.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<form method="post">{% csrf_token %}
+  <p class="text-danger">削除しますと復旧ができません。よろしいですか？</p>
+  <input type="submit" value="削除する">
+</form>
+{% endblock %}

--- a/templates/party/party_detail.html
+++ b/templates/party/party_detail.html
@@ -95,7 +95,7 @@
     <a href="{% url 'party:index'%}">編集</a>
   </div>
   <div class="delete">
-    <a href="{% url 'party:index'%}">削除</a>
+    <a href="{% url 'party:delete_party' party.pk%}">削除</a>
   </div>
   <div class="home">
     <a href="{% url 'party:index'%}">HOME</a>


### PR DESCRIPTION
## 概要
- 飲み会毎に削除ボタンを実装
- 削除の確認画面を遷移する形をとった
  - 削除機能の基礎を網羅できるため
  - コードが読みやすくなるため 


## 関連
close #110 


## 備考
- 確認画面不要で、削除確認をするパターン
https://djangobrothers.com/tutorials/memo_app/delete_edit/


## 参考
- Udemy
- https://itc.tokyo/django/delete-method/
