### PR TITLE
ボタンクリック時の巨大化解消

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -46,8 +46,6 @@
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
-{# --- 参加ボタン --- #}
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/4.0.0/mdb.min.js"></script>
 
 {% block extra_js %}{% endblock %}
 


### PR DESCRIPTION
## 概要
- 検証モードなどで確認したところ、jQueryのCDNが余分に読み込まれていることが原因であったため、いらない方を削除


## 関連
close #136


## 備考



## 参考
cdnjs：
https://cdnjs.com/libraries/jquery