### PR TITLE
Djangoのメール基礎設定

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from django.core.mail import send_mail
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -9,7 +10,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-xu*kflhns6ou3_e!x+cbjdhg@rgk#f^eimv#)zu&)kpl2-p1#@'
+SECRET_KEY = ''
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -174,4 +175,17 @@ ACCOUNT_FORMS = {
     'set_password': 'accounts.forms.CustomSetPasswordForm',
 }
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' #開発環境
+
+# Gmail
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_HOST_USER = 'drinkingpartyms@gmail.com'
+EMAIL_HOST_PASSWORD = ''
+EMAIL_USE_TLS = True
+
+subject = "This is MailSubject"
+message = "This is\nMailContent"
+from_email = 'drinkingpartyms@gmail.com'
+recipient_list = [""]
+send_mail(subject, message, from_email, recipient_list)

--- a/config/settings.py
+++ b/config/settings.py
@@ -173,3 +173,5 @@ ACCOUNT_FORMS = {
     'add_email': 'accounts.forms.CustomAddEmailForm',
     'set_password': 'accounts.forms.CustomSetPasswordForm',
 }
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
## 概要
- ローカル環境からメール配信を可能にする
  - プロバイダーは`Gmail `


- [x]  実際のメールを送信する代わりに、コンソールバックエンドは単に標準出力に送信されるメールを書き込み

- `.env`導入時に記載情報を削除

## 関連
close #139 


## 備考
ゆくゆくはSendGridの使用も試してみたい
https://sendgrid.kke.co.jp/docs/Integrate/Frameworks/django.html


## 参考
https://docs.djangoproject.com/ja/3.2/topics/email/
Gmailの最新設定
https://creepfablic.site/2022/06/21/python-gmail-smtpauthenticationerror/