### PR TITLE
シークレット情報を".ENV"へ分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .github/
 .DS_Store
 data/
+.env

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,12 +6,6 @@ from django.core.mail import send_mail
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
-
-SECRET_KEY = 'django-insecure-xu*kflhns6ou3_e!x+cbjdhg@rgk#f^eimv#)zu&)kpl2-p1#@'
-
 env = environ.Env(DEBUG=(bool, False),)
 environ.Env.read_env('.env')
 SECRET_KEY = env('SECRET_KEY')

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,14 +10,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-xu*kflhns6ou3_e!x+cbjdhg@rgk#f^eimv#)zu&)kpl2-p1#@'
-
-# SECURITY WARNING: don't run with debug turned on in production!
 
 env = environ.Env(DEBUG=(bool, False),)
 environ.Env.read_env('.env')
- 
 SECRET_KEY = env('SECRET_KEY')
 DEBUG = env('DEBUG')
  
@@ -187,12 +183,12 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' #開発環境
 # Gmail
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
-EMAIL_HOST_USER = 'drinkingpartyms@gmail.com'
-EMAIL_HOST_PASSWORD = ''
+EMAIL_HOST_USER = env('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
 EMAIL_USE_TLS = True
 
 subject = "This is MailSubject"
 message = "This is\nMailContent"
 from_email = 'drinkingpartyms@gmail.com'
-recipient_list = [""]
+recipient_list = ["comukichi@gmail.com"]
 send_mail(subject, message, from_email, recipient_list)

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,4 +1,5 @@
 import os
+import environ
 from pathlib import Path
 from django.core.mail import send_mail
 
@@ -10,13 +11,19 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ''
+SECRET_KEY = 'django-insecure-xu*kflhns6ou3_e!x+cbjdhg@rgk#f^eimv#)zu&)kpl2-p1#@'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
 
-ALLOWED_HOSTS = ['*'] ## SECURITY WARNING: don't run with [*] turned on in production!
-
+env = environ.Env(DEBUG=(bool, False),)
+environ.Env.read_env('.env')
+ 
+SECRET_KEY = env('SECRET_KEY')
+DEBUG = env('DEBUG')
+ 
+DATABASES = {
+    'default': env.db()
+}
 
 # Application definition
 # 自作アプリを追加する場合、上書きの必要なければ、下へ追加する

--- a/env_sample
+++ b/env_sample
@@ -1,0 +1,7 @@
+DEBUG=True
+ALLOWED_HOSTS=['*']
+SECRET_KEY=''
+DATABASE_URL=postgresql://postgres:postgres@host:/8000stgres
+#Gmail
+EMAIL_HOST_USER=''
+EMAIL_HOST_PASSWORD=''

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2>=2.8
 django-allauth
 django-bootstrap5
 django-bootstrap-datepicker-plus
+django-environ


### PR DESCRIPTION
## 概要
- シークレット情報がGit管理化にあるため、.env へ分離するための設定
- `django-environ` を利用


## 関連
close #142 


## 備考
docker-compose.yml の整理


## 参考
https://github.com/joke2k/django-environ

https://zenn.dev/hathle/articles/django-postgresql