### PR TITLE
出欠ボタン押下後に名簿へ反映させるようページリロードボタンを実装する

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,7 @@ Welcome ! {{ user.get_username }} さん
   </div>  
   <!-- ブロック2 -->
   <div class="col px-0 mx-0">
-    <div class="card" style="height: 100%;">
+    <div class="card" style="height: 100%; min-width: 450px;">
       <div class="card-body" style="font-size: 12px;">
         住所 :<p>{{ record.address| truncatechars:30 }}</p>
         <iframe id='map'

--- a/templates/party/party_detail.html
+++ b/templates/party/party_detail.html
@@ -48,7 +48,7 @@
             </div>
             <div class="delete ms-3 justify-content-end">
               <a href="{% url 'party:delete_party' party.pk%}">削除</a>
-            </div>    
+            </div>
           </div>
         </div>
       </div>
@@ -137,7 +137,10 @@
           <!-- /未定ボタン -->
       </div>
     </div>
-  </div>  
+    <p class="mt-1" style="font-size: 10px;">※名簿へ反映させるため出欠ボタン押下後は<br>
+      <a style="font-size: 14px;" href="javascript:location.reload();">更新</a>をクリックして下さい
+    </p>
+  </div>
   <!-- /右ブロック -->
 </div>
   {% block extrajs %}


### PR DESCRIPTION
## 概要
- 出欠ボタン押下後に名簿へ反映させるようページリロードボタンを実装
- 一部、地図の表示を修正


## 関連
close #144 


## 備考



## 参考
